### PR TITLE
migrator: add functional options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ prepare: setup-env mod-download
 .PHONY: mod-download
 mod-download:
 	@echo "Running download..."
-	go mod download GOPROXY="$(GOPROXY)"
+	GOPROXY="$(GOPROXY)" go mod download
 
 .PHONY: sanity-check
 sanity-check: golangci-lint

--- a/README.md
+++ b/README.md
@@ -49,15 +49,17 @@ import (
 
 func main() {
     m := migrator.New(
-        &migrator.Migration{
-            Name: "Create table foo",
-            Func: func(tx *sql.Tx) error {
-                if _, err := tx.Exec("CREATE TABLE foo (id INT PRIMARY KEY)"); err != nil {
-                    return err
-                }
-                return nil
+        Migrations(
+            &migrator.Migration{
+                Name: "Create table foo",
+                Func: func(tx *sql.Tx) error {
+                    if _, err := tx.Exec("CREATE TABLE foo (id INT PRIMARY KEY)"); err != nil {
+                        return err
+                    }
+                    return nil
+                },
             },
-        },
+        ),
     )
    
     // Migrate up
@@ -72,7 +74,7 @@ func main() {
 ```
 
 Notes on examples above:
-- Migrator creates/manages a table named `migrations` to keep track of the applied versions
+- Migrator creates/manages a table named `migrations` to keep track of the applied versions. However, if want to customize the table name `TableName("my_migrations")` can be also used.
 
 ### Looking for more examples?
 


### PR DESCRIPTION
This allows customizing migrator behaviour by exposing it's configurable
parts through functional options. This change starts by adding a
`Migrations` and `TableName` options to fullfil current requirements.

Closes #13
Superseeds #14