### PR TITLE
logger: implement logger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,23 @@ func main() {
 ```
 
 Notes on examples above:
-- Migrator creates/manages a table named `migrations` to keep track of the applied versions. However, if want to customize the table name `migrator.TableName("my_migrations")` can be passed to `migrator.New` function as an additional option. 
+
+- Migrator creates/manages a table named `migrations` to keep track of the applied versions. However, if you want to customize the table name `migrator.TableName("my_migrations")` can be passed to `migrator.New` function as an additional option. 
+
+### Logging
+
+By default, migrator prints applying/applied migration info to stdout. 
+If that's enough for you, you can skip this section.
+
+If you need some special formatting or want to use a 3rd party logging library, this could be done by using `WithLogger` option as follows:
+
+```go
+logger := migrator.WithLogger(migrator.LoggerFunc(func(msg string, args ...interface{}) {
+	// Your code here 
+})))
+```
+
+Then you will only need to pass the logger as an option to `migrator.New`. 
 
 ### Looking for more examples?
 

--- a/migrator_test.go
+++ b/migrator_test.go
@@ -5,6 +5,7 @@ package migrator
 import (
 	"database/sql"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
@@ -167,7 +168,7 @@ func TestBadMigrate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := migrate(db, "BAD INSERT VERSION", &Migration{Name: "bad insert version", Func: func(tx *sql.Tx) error {
+	if err := migrate(db, log.New(os.Stdout, "migrator: ", 0), "BAD INSERT VERSION", &Migration{Name: "bad insert version", Func: func(tx *sql.Tx) error {
 		return nil
 	}}); err == nil {
 		t.Fatal("BAD INSERT VERSION should fail!")
@@ -179,7 +180,7 @@ func TestBadMigrateNoTx(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := migrateNoTx(db, "BAD INSERT VERSION", &MigrationNoTx{Name: "bad migrate no tx", Func: func(db *sql.DB) error {
+	if err := migrateNoTx(db, log.New(os.Stdout, "migrator: ", 0), "BAD INSERT VERSION", &MigrationNoTx{Name: "bad migrate no tx", Func: func(db *sql.DB) error {
 		return nil
 	}}); err == nil {
 		t.Fatal("BAD INSERT VERSION should fail!")


### PR DESCRIPTION
Add a Logger interface, along with a LoggerFunc and a new WithLogger option.

This would enable:

- Customizing migrator output
- Integrating a 3rd party logging tool

By default, migrator will work as before, just outputting to stdout.

Closes #6